### PR TITLE
Improve type hints

### DIFF
--- a/src/color_code_stim/color_code.py
+++ b/src/color_code_stim/color_code.py
@@ -382,7 +382,9 @@ class ColorCode:
         return self.obs_paulis[observable_id]
 
     @timeit
-    def _create_tanner_graph(self):
+    def _create_tanner_graph(self) -> None:
+        """Construct the Tanner graph for the chosen circuit type."""
+
         circuit_type = self.circuit_type
         tanner_graph = self.tanner_graph
 

--- a/src/color_code_stim/dem_decomp.py
+++ b/src/color_code_stim/dem_decomp.py
@@ -113,8 +113,13 @@ class DemDecomp:
 
         # self._best_org_error_map = self._precompute_best_org_error_map()
 
-    def __repr__(self):
-        return f"<DemDecomp object with color='{self.color}', Hs[0].shape={self.Hs[0].shape}, Hs[1].shape={self.Hs[1].shape}>"
+    def __repr__(self) -> str:
+        """Return the string representation of this object."""
+
+        return (
+            f"<DemDecomp object with color='{self.color}', "
+            f"Hs[0].shape={self.Hs[0].shape}, Hs[1].shape={self.Hs[1].shape}>"
+        )
 
     def decompose_org_dem(
         self,
@@ -301,31 +306,33 @@ class DemDecomp:
         errors_org = errors @ error_map_matrix
         return errors_org
 
-    def __iter__(self):
+    def __iter__(self) -> "Iterator[stim.DetectorErrorModel]":
         """
-        Iterate over the decomposed detector error models.
+        Return an iterator over the decomposed detector error models.
 
         Returns
         -------
-        iterator
-            Iterator over the dems tuple (restricted DEM, monochromatic DEM).
+        Iterator of stim.DetectorErrorModel
+            Yields the restricted and monochromatic detector error models.
         """
+
         return iter(self._dems)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> stim.DetectorErrorModel:
         """
-        Access the decomposed detector error models by index.
+        Access one of the decomposed detector error models by index.
 
         Parameters
         ----------
         idx : int
-            Index of the detector error model to access (0 for restricted DEM, 1 for monochromatic DEM).
+            ``0`` for the restricted model or ``1`` for the monochromatic model.
 
         Returns
         -------
         stim.DetectorErrorModel
-            The requested detector error model.
+            The selected detector error model.
         """
+
         return self._dems[idx]
 
     # def _precompute_best_org_error_map(self):

--- a/src/color_code_stim/stim_symbolic.py
+++ b/src/color_code_stim/stim_symbolic.py
@@ -43,8 +43,15 @@ class _ErrorMechanismSymbolic:
         self.dets = set(dets)
         self.obss = set(obss)
 
-    def __repr__(self):
-        return f"_ErrorMechanismSymbolic(dets={{{', '.join(str(det) for det in self.dets)}}}, obss={{{', '.join(str(obs) for obs in self.obss)}}}, prob_vars={self.prob_vars}, prob_muls={self.prob_muls})"
+    def __repr__(self) -> str:
+        """Return a concise string representation of this error mechanism."""
+
+        return (
+            "_ErrorMechanismSymbolic("
+            f"dets={{{ {', '.join(str(det) for det in self.dets)} }}}, "
+            f"obss={{{ {', '.join(str(obs) for obs in self.obss)} }}}, "
+            f"prob_vars={self.prob_vars}, prob_muls={self.prob_muls})"
+        )
 
 
 class _DemSymbolic:
@@ -71,16 +78,19 @@ class _DemSymbolic:
 
         self.update_error_map_matrix()
 
-    def __iter__(self):
-        """Iterate through the error mechanisms."""
+    def __iter__(self) -> "Iterator[_ErrorMechanismSymbolic]":
+        """Return an iterator over the error mechanisms."""
+
         return iter(self._ems)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the number of error mechanisms."""
+
         return len(self._ems)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int | slice) -> _ErrorMechanismSymbolic | List[_ErrorMechanismSymbolic]:
         """Access error mechanisms by index or slice."""
+
         return self._ems[key]
 
     @classmethod
@@ -101,12 +111,12 @@ class _DemSymbolic:
         new_dem.update_error_map_matrix()
         return new_dem
 
-    def update_error_map_matrix(self):
+    def update_error_map_matrix(self) -> None:
         """
-        Updates the error_map_matrix based on the current self.ems list.
+        Recalculate ``error_map_matrix`` from the current error mechanisms.
 
-        Determines the number of variables by finding the maximum index used
-        in any em.prob_vars array. Updates self.error_map_matrix in place.
+        The matrix maps indices of decomposed errors to indices of the original
+        error mechanisms.
         """
         num_errors = len(self._ems)
         if num_errors == 0:

--- a/src/color_code_stim/stim_utils.py
+++ b/src/color_code_stim/stim_utils.py
@@ -273,10 +273,27 @@ def dem_to_parity_check(
 #     return obs_matrix
 
 
-def save_circuit_diagram(circuit: stim.Circuit, path: str, type: str = "timeline-svg"):
+def save_circuit_diagram(
+    circuit: stim.Circuit, path: str, type: str = "timeline-svg"
+) -> None:
     """
-    Save a circuit diagram to a file.
+    Save a textual diagram of ``circuit`` to ``path``.
+
+    Parameters
+    ----------
+    circuit : stim.Circuit
+        Circuit whose diagram will be saved.
+    path : str
+        File path for the output diagram.
+    type : str, default 'timeline-svg'
+        Format used by ``stim.Circuit.diagram``.
+
+    Returns
+    -------
+    None
+        This function writes to disk and does not return a value.
     """
+
     print(circuit.diagram(type=type), file=open(path, "w"))
 
 

--- a/src/color_code_stim/visualization.py
+++ b/src/color_code_stim/visualization.py
@@ -207,10 +207,25 @@ def draw_lattice(
     color_map = {"r": "red", "g": "green", "b": "blue"}
 
     # Function to lighten a color based on alpha value
-    def lighten_color(color, alpha_factor):
-        # Convert color to RGB
+    def lighten_color(color: str, alpha_factor: float) -> Tuple[float, float, float]:
+        """
+        Return a lighter version of ``color`` controlled by ``alpha_factor``.
+
+        Parameters
+        ----------
+        color : str
+            Matplotlib-compatible color specification.
+        alpha_factor : float
+            Value in ``[0, 1]`` controlling the blend with white. ``0`` yields the
+            lightest color.
+
+        Returns
+        -------
+        r, g, b : 3-tuple of float
+            Lightened RGB color values.
+        """
+
         r, g, b = to_rgb(color)
-        # Mix with white based on alpha
         r = r + (1 - r) * (1 - alpha_factor)
         g = g + (1 - g) * (1 - alpha_factor)
         b = b + (1 - b) * (1 - alpha_factor)


### PR DESCRIPTION
## Summary
- add return annotation for `_create_tanner_graph`
- annotate DemDecomp helper methods
- enrich symbolic classes with type hints
- document `save_circuit_diagram`
- add helper docstring in `draw_lattice`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*